### PR TITLE
Restructure to use ManuscriptWriter instances

### DIFF
--- a/binder-app/src/main/java/net/kemitix/binder/app/BinderApp.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/BinderApp.java
@@ -38,7 +38,7 @@ public class BinderApp {
     public void run(String[] args) {
         log.info("Binder - Starting");
         epubWriter.write();
-        docxWriter.write(docxFactory.create());
+        docxWriter.write();
         log.info("Binder - Done.");
     }
 

--- a/binder-app/src/main/java/net/kemitix/binder/app/BinderApp.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/BinderApp.java
@@ -37,7 +37,6 @@ public class BinderApp {
 
     public void run(String[] args) {
         log.info("Binder - Starting");
-        htmlFactory.createAll();
         epubWriter.write(epubFactory.create());
         docxWriter.write(docxFactory.create());
         log.info("Binder - Done.");

--- a/binder-app/src/main/java/net/kemitix/binder/app/BinderApp.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/BinderApp.java
@@ -8,11 +8,14 @@ import net.kemitix.binder.app.epub.EpubFactory;
 import net.kemitix.binder.app.epub.EpubWriter;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
 @Log
 @ApplicationScoped
 public class BinderApp {
+
+    private final Instance<ManuscriptWriter> writers;
 
     private final HtmlFactory htmlFactory;
     private final EpubFactory epubFactory;
@@ -22,12 +25,14 @@ public class BinderApp {
 
     @Inject
     public BinderApp(
+            Instance<ManuscriptWriter> writers,
             HtmlFactory htmlFactory,
             EpubFactory epubFactory,
             EpubWriter epubWriter,
             DocxWriter docxWriter,
             DocxFactory docxFactory
     ) {
+        this.writers = writers;
         this.htmlFactory = htmlFactory;
         this.epubFactory = epubFactory;
         this.epubWriter = epubWriter;
@@ -37,8 +42,8 @@ public class BinderApp {
 
     public void run(String[] args) {
         log.info("Binder - Starting");
-        epubWriter.write();
-        docxWriter.write();
+        writers.stream()
+                .forEach(ManuscriptWriter::write);
         log.info("Binder - Done.");
     }
 

--- a/binder-app/src/main/java/net/kemitix/binder/app/BinderApp.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/BinderApp.java
@@ -1,11 +1,6 @@
 package net.kemitix.binder.app;
 
 import lombok.extern.java.Log;
-import net.kemitix.binder.app.docx.DocxFactory;
-import net.kemitix.binder.app.docx.DocxWriter;
-import net.kemitix.binder.app.epub.EpubContentFactory;
-import net.kemitix.binder.app.epub.EpubFactory;
-import net.kemitix.binder.app.epub.EpubWriter;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
@@ -17,27 +12,11 @@ public class BinderApp {
 
     private final Instance<ManuscriptWriter> writers;
 
-    private final HtmlFactory htmlFactory;
-    private final EpubFactory epubFactory;
-    private final EpubWriter epubWriter;
-    private final DocxWriter docxWriter;
-    private final DocxFactory docxFactory;
-
     @Inject
     public BinderApp(
-            Instance<ManuscriptWriter> writers,
-            HtmlFactory htmlFactory,
-            EpubFactory epubFactory,
-            EpubWriter epubWriter,
-            DocxWriter docxWriter,
-            DocxFactory docxFactory
+            Instance<ManuscriptWriter> writers
     ) {
         this.writers = writers;
-        this.htmlFactory = htmlFactory;
-        this.epubFactory = epubFactory;
-        this.epubWriter = epubWriter;
-        this.docxWriter = docxWriter;
-        this.docxFactory = docxFactory;
     }
 
     public void run(String[] args) {

--- a/binder-app/src/main/java/net/kemitix/binder/app/BinderApp.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/BinderApp.java
@@ -37,7 +37,7 @@ public class BinderApp {
 
     public void run(String[] args) {
         log.info("Binder - Starting");
-        epubWriter.write(epubFactory.create());
+        epubWriter.write();
         docxWriter.write(docxFactory.create());
         log.info("Binder - Done.");
     }

--- a/binder-app/src/main/java/net/kemitix/binder/app/HtmlFactory.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/HtmlFactory.java
@@ -9,18 +9,18 @@ import java.nio.file.Path;
 @ApplicationScoped
 public class HtmlFactory {
 
-    private final Manuscript manuscript;
+    private final MdManuscript mdManuscript;
     private final MarkdownToHtml markdownToHtml;
     private final BinderConfig binderConfig;
 
     @Inject
     public HtmlFactory(
             BinderConfig binderConfig,
-            Manuscript manuscript,
+            MdManuscript mdManuscript,
             MarkdownToHtml markdownToHtml
     ) {
         this.binderConfig = binderConfig;
-        this.manuscript = manuscript;
+        this.mdManuscript = mdManuscript;
         this.markdownToHtml = markdownToHtml;
     }
 
@@ -28,7 +28,7 @@ public class HtmlFactory {
      * Creates HTML files for all sections in Manuscript.
      */
     public void createAll() {
-        manuscript.getContents()
+        mdManuscript.getContents()
                 .forEach(this::createHtmlForSection);
     }
 

--- a/binder-app/src/main/java/net/kemitix/binder/app/HtmlManuscript.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/HtmlManuscript.java
@@ -1,0 +1,38 @@
+package net.kemitix.binder.app;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.With;
+
+import javax.enterprise.inject.Vetoed;
+import java.util.Map;
+
+@Getter
+@With
+@Vetoed
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class HtmlManuscript {
+
+    private MdManuscript mdManuscript;
+    private Map<String, String> htmlSections;
+
+    static HtmlManuscript.HtmlBuilder htmlBuilder() {
+        return mdManuscript -> htmlSections ->
+                new HtmlManuscript(mdManuscript, htmlSections);
+    }
+
+    public Metadata getMetadata() {
+        return mdManuscript.getMetadata();
+    }
+
+    public interface HtmlBuilder {
+        HtmlManuscript.HtmlBuilder.Stage1 metadata(MdManuscript mdManuscript);
+        interface Stage1 {
+            HtmlManuscript htmlSections(Map<String, String> htmlSections);
+        }
+    }
+
+}

--- a/binder-app/src/main/java/net/kemitix/binder/app/ManuscriptLoader.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/ManuscriptLoader.java
@@ -43,8 +43,8 @@ public class ManuscriptLoader {
 
     @Produces
     @ApplicationScoped
-    Manuscript manuscript(Metadata metadata) {
-        return Manuscript.builder()
+    MdManuscript manuscript(Metadata metadata) {
+        return MdManuscript.builder()
                 .metadata(metadata)
                 .contents(loadSections(metadata.getContents()));
     }

--- a/binder-app/src/main/java/net/kemitix/binder/app/ManuscriptLoader.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/ManuscriptLoader.java
@@ -5,7 +5,11 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import java.io.File;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
@@ -43,7 +47,7 @@ public class ManuscriptLoader {
 
     @Produces
     @ApplicationScoped
-    MdManuscript manuscript(Metadata metadata) {
+    MdManuscript mdManuscript(Metadata metadata) {
         return MdManuscript.builder()
                 .metadata(metadata)
                 .contents(loadSections(metadata.getContents()));
@@ -56,6 +60,23 @@ public class ManuscriptLoader {
         return filenames.stream()
                 .map(sectionLoader::load)
                 .collect(Collectors.toList());
+    }
+
+    @Produces
+    @ApplicationScoped
+    HtmlManuscript htmlManuscript(
+            MdManuscript mdManuscript,
+            MarkdownToHtml markdownToHtml
+    ) {
+        Map<String, String> htmlSections = new LinkedHashMap<>();
+        mdManuscript.getContents()
+                .forEach(section ->
+                        htmlSections.put(
+                                section.getName(),
+                                markdownToHtml.apply(section)));
+        return HtmlManuscript.htmlBuilder()
+                .metadata(mdManuscript)
+                .htmlSections(htmlSections);
     }
 
 }

--- a/binder-app/src/main/java/net/kemitix/binder/app/ManuscriptWriter.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/ManuscriptWriter.java
@@ -1,2 +1,7 @@
-package net.kemitix.binder.app;public interface ManuscriptWriter {
+package net.kemitix.binder.app;
+
+public interface ManuscriptWriter {
+
+    void write();
+
 }

--- a/binder-app/src/main/java/net/kemitix/binder/app/ManuscriptWriter.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/ManuscriptWriter.java
@@ -1,0 +1,2 @@
+package net.kemitix.binder.app;public interface ManuscriptWriter {
+}

--- a/binder-app/src/main/java/net/kemitix/binder/app/MarkdownToHtmlProducer.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/MarkdownToHtmlProducer.java
@@ -13,7 +13,7 @@ public class MarkdownToHtmlProducer {
     @Produces
     MarkdownToHtml markdownToHtml(
             TemplateEngine templateEngine,
-            Manuscript manuscript
+            MdManuscript mdManuscript
     ) {
         MutableDataSet dataSet = new MutableDataSet();
         Parser parser = Parser.builder(dataSet).build();
@@ -22,19 +22,19 @@ public class MarkdownToHtmlProducer {
                 renderTemplate(
                         renderer.render(parser.parse(section.getMarkdown())),
                         section,
-                        manuscript,
+                        mdManuscript,
                         templateEngine);
     }
 
     private String renderTemplate(
             String rawHtml,
             Section section,
-            Manuscript manuscript,
+            MdManuscript mdManuscript,
             TemplateEngine templateEngine) {
         return "<html><head><title>%s</title></head>\n<body>\n\n%s\n</body>\n</html>"
                 .formatted(
                         section.getTitle(),
-                        templateEngine.resolve(rawHtml, section, manuscript));
+                        templateEngine.resolve(rawHtml, section, mdManuscript));
     }
 
 }

--- a/binder-app/src/main/java/net/kemitix/binder/app/MarkdownToHtmlProducer.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/MarkdownToHtmlProducer.java
@@ -19,22 +19,20 @@ public class MarkdownToHtmlProducer {
         Parser parser = Parser.builder(dataSet).build();
         HtmlRenderer renderer = HtmlRenderer.builder().build();
         return section ->
-                renderTemplate(
-                        renderer.render(parser.parse(section.getMarkdown())),
-                        section,
-                        mdManuscript,
-                        templateEngine);
-    }
-
-    private String renderTemplate(
-            String rawHtml,
-            Section section,
-            MdManuscript mdManuscript,
-            TemplateEngine templateEngine) {
-        return "<html><head><title>%s</title></head>\n<body>\n\n%s\n</body>\n</html>"
-                .formatted(
-                        section.getTitle(),
-                        templateEngine.resolve(rawHtml, section, mdManuscript));
+        {
+            String markdown = section.getMarkdown();
+            String htmlBodyTemplate = renderer.render(parser.parse(markdown));
+            String htmlBody =
+                    templateEngine.resolve(
+                            htmlBodyTemplate, section, mdManuscript);
+            return ("<html><head><title>%s</title></head>\n" +
+                    "<body>\n" +
+                    "\n" +
+                    "%s\n" +
+                    "</body>\n" +
+                    "</html>")
+                    .formatted(section.getTitle(), htmlBody);
+        };
     }
 
 }

--- a/binder-app/src/main/java/net/kemitix/binder/app/MdManuscript.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/MdManuscript.java
@@ -14,20 +14,20 @@ import java.util.List;
 @Vetoed
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Manuscript {
+public class MdManuscript {
 
     private Metadata metadata;
 
     private List<Section> contents;
 
     static Builder builder() {
-        return metadata -> contents -> new Manuscript(metadata, contents);
+        return metadata -> contents -> new MdManuscript(metadata, contents);
     }
 
     public interface Builder {
         Stage1 metadata(Metadata metadata);
         interface Stage1 {
-            Manuscript contents(List<Section> sections);
+            MdManuscript contents(List<Section> sections);
         }
     }
 }

--- a/binder-app/src/main/java/net/kemitix/binder/app/Section.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/Section.java
@@ -30,7 +30,9 @@ public class Section {
     private int copyright; // the year the story was copyrighted
     private File filename; // the file loaded
     private String markdown; // the markdown contents of the file, after removing yaml header
+    @Deprecated
     private File htmlFile;
+    @Deprecated
     private String html;
 
 }

--- a/binder-app/src/main/java/net/kemitix/binder/app/TemplateEngine.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/TemplateEngine.java
@@ -8,6 +8,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.time.Instant;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
@@ -27,6 +28,7 @@ public class TemplateEngine {
             MdManuscript mdManuscript
     ) {
         Context context = new VelocityContext();
+        context.put("timestamp", Instant.now().toString());
         context.put("m", mdManuscript.getMetadata());
         context.put("c", mdManuscript.getContents());
         context.put("s", section);

--- a/binder-app/src/main/java/net/kemitix/binder/app/TemplateEngine.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/TemplateEngine.java
@@ -24,20 +24,20 @@ public class TemplateEngine {
     public String resolve(
             String templateBody,
             Section section,
-            Manuscript manuscript
+            MdManuscript mdManuscript
     ) {
         Context context = new VelocityContext();
-        context.put("m", manuscript.getMetadata());
-        context.put("c", manuscript.getContents());
+        context.put("m", mdManuscript.getMetadata());
+        context.put("c", mdManuscript.getContents());
         context.put("s", section);
-        context.put("copyrights", copyrights(manuscript));
+        context.put("copyrights", copyrights(mdManuscript));
         Writer writer = new StringWriter();
         velocityEngine.evaluate(context, writer, "", templateBody);
         return writer.toString();
     }
 
-    private String copyrights(Manuscript manuscript) {
-        return manuscript.getContents().stream()
+    private String copyrights(MdManuscript mdManuscript) {
+        return mdManuscript.getContents().stream()
                 .filter(section -> "story".equals(section.getType()))
                 .map(section -> "%s ©%s by%s%s".formatted(
                         section.getTitle(),

--- a/binder-app/src/main/java/net/kemitix/binder/app/docx/DocxBook.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/docx/DocxBook.java
@@ -1,31 +1,24 @@
 package net.kemitix.binder.app.docx;
 
-import com.fasterxml.jackson.databind.deser.std.CollectionDeserializer;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.extern.java.Log;
 
+import javax.enterprise.inject.Vetoed;
 import java.util.ArrayList;
 import java.util.List;
 
 @Log
+@Vetoed
+@NoArgsConstructor
+@AllArgsConstructor
 public class DocxBook {
 
-    private final String language;
-    private final String id;
-    private final String title;
-    private final String editor;
+    private String language;
+    private String id;
+    private String title;
+    private String editor;
     private final List<DocxContent> content = new ArrayList<>();
-
-    public DocxBook(
-            String language,
-            String id,
-            String title,
-            String editor
-    ) {
-        this.language = language;
-        this.id = id;
-        this.title = title;
-        this.editor = editor;
-    }
 
     public void writeToFile(String file) {
         //TODO write self to file

--- a/binder-app/src/main/java/net/kemitix/binder/app/docx/DocxContentFactory.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/docx/DocxContentFactory.java
@@ -1,33 +1,23 @@
 package net.kemitix.binder.app.docx;
 
 import lombok.extern.java.Log;
-import net.kemitix.binder.app.Section;
-import org.docx4j.XmlUtils;
 import org.docx4j.convert.in.xhtml.XHTMLImporterImpl;
 import org.docx4j.jaxb.Context;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
-import org.docx4j.openpackaging.exceptions.InvalidFormatException;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.openpackaging.parts.WordprocessingML.NumberingDefinitionsPart;
 import org.docx4j.wml.RFonts;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.xml.bind.JAXBException;
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 
 @Log
 @ApplicationScoped
 public class DocxContentFactory {
 
-    public DocxContent create(Section section) {
-        log.info(String.format("Created Content: %s",
-                section.getHtmlFile().getName()));
+    public DocxContent create(String name, String html) {
+        log.info(String.format("Created Content: %s", name));
         try {
-            File htmlFile = section.getHtmlFile();
-            String unescaped = Files.readString(htmlFile.toPath(), StandardCharsets.UTF_8);
             String baseURL = "BASEURL";
             RFonts rfonts = Context.getWmlObjectFactory().createRFonts();
             rfonts.setAscii("Century Gothic");
@@ -39,17 +29,12 @@ public class DocxContentFactory {
             XHTMLImporterImpl XHTMLImporter = new XHTMLImporterImpl(wordMLPackage);
             XHTMLImporter.setHyperlinkStyle("Hyperlink");
             wordMLPackage.getMainDocumentPart().getContent().addAll(
-                    XHTMLImporter.convert(unescaped, baseURL));
+                    XHTMLImporter.convert(html, baseURL));
             return new DocxContent(wordMLPackage);
-        } catch (Docx4JException | IOException | JAXBException e) {
-            try {
-                log.severe(Files.readString(section.getHtmlFile().toPath()));
-            } catch (IOException ioException) {
-                ioException.printStackTrace();
-            }
+        } catch (Docx4JException | JAXBException e) {
             throw new RuntimeException(
                     "Error create docx from HTML file for: %s"
-                            .formatted(section.getTitle()), e);
+                            .formatted(name), e);
         }
     }
 }

--- a/binder-app/src/main/java/net/kemitix/binder/app/docx/DocxFactory.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/docx/DocxFactory.java
@@ -2,7 +2,7 @@ package net.kemitix.binder.app.docx;
 
 import lombok.extern.java.Log;
 import net.kemitix.binder.app.BinderConfig;
-import net.kemitix.binder.app.Manuscript;
+import net.kemitix.binder.app.MdManuscript;
 import net.kemitix.binder.app.Metadata;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -13,24 +13,24 @@ import javax.inject.Inject;
 public class DocxFactory {
 
     private final BinderConfig binderConfig;
-    private final Manuscript manuscript;
+    private final MdManuscript mdManuscript;
     private final DocxContentFactory docxContextFactory;
 
     @Inject
     public DocxFactory(
             BinderConfig binderConfig,
-            Manuscript manuscript,
+            MdManuscript mdManuscript,
             DocxContentFactory docxContextFactory
     ) {
         this.binderConfig = binderConfig;
-        this.manuscript = manuscript;
+        this.mdManuscript = mdManuscript;
         this.docxContextFactory = docxContextFactory;
     }
 
     public DocxBook create() {
-        Metadata metadata = manuscript.getMetadata();
+        Metadata metadata = mdManuscript.getMetadata();
         DocxBook docx = createDocxBook(metadata);
-        manuscript.getContents().stream()
+        mdManuscript.getContents().stream()
                 .map(docxContextFactory::create)
                 .forEach(docx::addContent);
         return docx;

--- a/binder-app/src/main/java/net/kemitix/binder/app/docx/DocxFactory.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/docx/DocxFactory.java
@@ -7,6 +7,7 @@ import net.kemitix.binder.app.MdManuscript;
 import net.kemitix.binder.app.Metadata;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
 @Log
@@ -28,6 +29,8 @@ public class DocxFactory {
         this.docxContextFactory = docxContextFactory;
     }
 
+    @Produces
+    @ApplicationScoped
     public DocxBook create() {
         Metadata metadata = htmlManuscript.getMetadata();
         DocxBook docx = createDocxBook(metadata);

--- a/binder-app/src/main/java/net/kemitix/binder/app/docx/DocxFactory.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/docx/DocxFactory.java
@@ -2,6 +2,7 @@ package net.kemitix.binder.app.docx;
 
 import lombok.extern.java.Log;
 import net.kemitix.binder.app.BinderConfig;
+import net.kemitix.binder.app.HtmlManuscript;
 import net.kemitix.binder.app.MdManuscript;
 import net.kemitix.binder.app.Metadata;
 
@@ -13,25 +14,25 @@ import javax.inject.Inject;
 public class DocxFactory {
 
     private final BinderConfig binderConfig;
-    private final MdManuscript mdManuscript;
+    private final HtmlManuscript htmlManuscript;
     private final DocxContentFactory docxContextFactory;
 
     @Inject
     public DocxFactory(
             BinderConfig binderConfig,
-            MdManuscript mdManuscript,
+            HtmlManuscript htmlManuscript,
             DocxContentFactory docxContextFactory
     ) {
         this.binderConfig = binderConfig;
-        this.mdManuscript = mdManuscript;
+        this.htmlManuscript = htmlManuscript;
         this.docxContextFactory = docxContextFactory;
     }
 
     public DocxBook create() {
-        Metadata metadata = mdManuscript.getMetadata();
+        Metadata metadata = htmlManuscript.getMetadata();
         DocxBook docx = createDocxBook(metadata);
-        mdManuscript.getContents().stream()
-                .map(docxContextFactory::create)
+        htmlManuscript.getHtmlSections().entrySet().stream()
+                .map(e -> docxContextFactory.create(e.getKey(), e.getValue()))
                 .forEach(docx::addContent);
         return docx;
     }

--- a/binder-app/src/main/java/net/kemitix/binder/app/docx/DocxWriter.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/docx/DocxWriter.java
@@ -9,13 +9,18 @@ import javax.inject.Inject;
 public class DocxWriter {
 
     private final BinderConfig binderConfig;
+    private final DocxBook docxBook;
 
     @Inject
-    public DocxWriter(BinderConfig binderConfig) {
+    public DocxWriter(
+            BinderConfig binderConfig,
+            DocxBook docxBook
+    ) {
         this.binderConfig = binderConfig;
+        this.docxBook = docxBook;
     }
 
-    public void write(DocxBook docxBook) {
+    public void write() {
         String docxFile = binderConfig.getDocxFile().getAbsolutePath();
         try {
             docxBook.writeToFile(docxFile);

--- a/binder-app/src/main/java/net/kemitix/binder/app/docx/DocxWriter.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/docx/DocxWriter.java
@@ -1,12 +1,13 @@
 package net.kemitix.binder.app.docx;
 
 import net.kemitix.binder.app.BinderConfig;
+import net.kemitix.binder.app.ManuscriptWriter;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 @ApplicationScoped
-public class DocxWriter {
+public class DocxWriter implements ManuscriptWriter {
 
     private final BinderConfig binderConfig;
     private final DocxBook docxBook;

--- a/binder-app/src/main/java/net/kemitix/binder/app/epub/EpubContentFactory.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/epub/EpubContentFactory.java
@@ -2,31 +2,21 @@ package net.kemitix.binder.app.epub;
 
 import coza.opencollab.epub.creator.model.Content;
 import lombok.extern.java.Log;
-import net.kemitix.binder.app.Section;
 
 import javax.enterprise.context.ApplicationScoped;
-import java.io.IOException;
-import java.nio.file.Files;
+import java.nio.charset.StandardCharsets;
 
 @Log
 @ApplicationScoped
 public class EpubContentFactory {
-    public Content create(Section section) {
-        byte[] bytes = readFile(section);
+
+    public Content create(String name, String html) {
+        byte[] bytes = html.getBytes(StandardCharsets.UTF_8);
         String mediaType = "application/xhtml+xml";
-        String href = "content/%s.html".formatted(section.getName());
+        String href = "content/%s.html".formatted(name);
         log.info(String.format("Created Content: %s (%s) [%d bytes] %s",
-                href, mediaType, bytes.length, section.getHtmlFile().getName()));
+                href, mediaType, bytes.length, name));
         return new Content(mediaType, href, bytes);
     }
 
-    private byte[] readFile(Section section) {
-        try {
-            return Files.readAllBytes(section.getHtmlFile().toPath());
-        } catch (IOException e) {
-            throw new RuntimeException(String.format(
-                    "Error reading HTML file %s: %s",
-                    section.getName(), e.getMessage()), e);
-        }
-    }
 }

--- a/binder-app/src/main/java/net/kemitix/binder/app/epub/EpubFactory.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/epub/EpubFactory.java
@@ -3,7 +3,7 @@ package net.kemitix.binder.app.epub;
 import coza.opencollab.epub.creator.model.EpubBook;
 import lombok.extern.java.Log;
 import net.kemitix.binder.app.BinderConfig;
-import net.kemitix.binder.app.Manuscript;
+import net.kemitix.binder.app.MdManuscript;
 import net.kemitix.binder.app.Metadata;
 import org.jetbrains.annotations.NotNull;
 
@@ -18,27 +18,27 @@ import java.nio.file.Path;
 public class EpubFactory {
 
     private final BinderConfig binderConfig;
-    private final Manuscript manuscript;
+    private final MdManuscript mdManuscript;
     private final EpubContentFactory epubContentFactory;
 
     @Inject
     public EpubFactory(
             BinderConfig binderConfig,
-            Manuscript manuscript,
+            MdManuscript mdManuscript,
             EpubContentFactory epubContentFactory
     ) {
         this.binderConfig = binderConfig;
-        this.manuscript = manuscript;
+        this.mdManuscript = mdManuscript;
         this.epubContentFactory = epubContentFactory;
     }
 
     public EpubBook create() {
-        Metadata metadata = manuscript.getMetadata();
+        Metadata metadata = mdManuscript.getMetadata();
         EpubBook epub = createEpub(metadata);
         epub.addCoverImage(coverImage(metadata.getCover()),
                 "image/jpeg", "cover.jpg");
         epub.addTextContent("Cover", "cover.html", "<img src=\"cover.jpg\" style=\"height:100%\"/>");
-        manuscript.getContents().stream()
+        mdManuscript.getContents().stream()
                 .map(epubContentFactory::create)
                 .forEach(epub::addContent);
         return epub;

--- a/binder-app/src/main/java/net/kemitix/binder/app/epub/EpubFactory.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/epub/EpubFactory.java
@@ -3,11 +3,12 @@ package net.kemitix.binder.app.epub;
 import coza.opencollab.epub.creator.model.EpubBook;
 import lombok.extern.java.Log;
 import net.kemitix.binder.app.BinderConfig;
-import net.kemitix.binder.app.MdManuscript;
+import net.kemitix.binder.app.HtmlManuscript;
 import net.kemitix.binder.app.Metadata;
 import org.jetbrains.annotations.NotNull;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -18,28 +19,32 @@ import java.nio.file.Path;
 public class EpubFactory {
 
     private final BinderConfig binderConfig;
-    private final MdManuscript mdManuscript;
+    private final HtmlManuscript htmlManuscript;
     private final EpubContentFactory epubContentFactory;
 
     @Inject
     public EpubFactory(
             BinderConfig binderConfig,
-            MdManuscript mdManuscript,
+            HtmlManuscript htmlManuscript,
             EpubContentFactory epubContentFactory
     ) {
         this.binderConfig = binderConfig;
-        this.mdManuscript = mdManuscript;
+        this.htmlManuscript = htmlManuscript;
         this.epubContentFactory = epubContentFactory;
     }
 
+    @Produces
+    @ApplicationScoped
     public EpubBook create() {
-        Metadata metadata = mdManuscript.getMetadata();
+        Metadata metadata = htmlManuscript.getMetadata();
         EpubBook epub = createEpub(metadata);
         epub.addCoverImage(coverImage(metadata.getCover()),
                 "image/jpeg", "cover.jpg");
         epub.addTextContent("Cover", "cover.html", "<img src=\"cover.jpg\" style=\"height:100%\"/>");
-        mdManuscript.getContents().stream()
-                .map(epubContentFactory::create)
+        htmlManuscript.getHtmlSections()
+                .entrySet()
+                .stream()
+                .map(e -> epubContentFactory.create(e.getKey(), e.getValue()))
                 .forEach(epub::addContent);
         return epub;
     }

--- a/binder-app/src/main/java/net/kemitix/binder/app/epub/EpubWriter.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/epub/EpubWriter.java
@@ -2,6 +2,7 @@ package net.kemitix.binder.app.epub;
 
 import coza.opencollab.epub.creator.model.EpubBook;
 import net.kemitix.binder.app.BinderConfig;
+import net.kemitix.binder.app.ManuscriptWriter;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -10,7 +11,7 @@ import javax.inject.Inject;
  * Writes the Epub file to disk
  */
 @ApplicationScoped
-public class EpubWriter {
+public class EpubWriter implements ManuscriptWriter {
 
     private final BinderConfig binderConfig;
     private final EpubBook epubBook;

--- a/binder-app/src/main/java/net/kemitix/binder/app/epub/EpubWriter.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/epub/EpubWriter.java
@@ -13,13 +13,17 @@ import javax.inject.Inject;
 public class EpubWriter {
 
     private final BinderConfig binderConfig;
+    private final EpubBook epubBook;
 
     @Inject
-    public EpubWriter(BinderConfig binderConfig) {
+    public EpubWriter(
+            BinderConfig binderConfig,
+            EpubBook epubBook) {
         this.binderConfig = binderConfig;
+        this.epubBook = epubBook;
     }
 
-    public void write(EpubBook epubBook) {
+    public void write() {
         String epubFile = binderConfig.getEpubFile().getAbsolutePath();
         try {
             epubBook.writeToFile(epubFile);

--- a/binder-app/src/test/java/net/kemitix/binder/app/BinderTest.java
+++ b/binder-app/src/test/java/net/kemitix/binder/app/BinderTest.java
@@ -38,19 +38,14 @@ public class BinderTest
     VelocityEngine velocityEngine = new VelocityProvider().velocityEngine();
     TemplateEngine templateEngine = new TemplateEngine(velocityEngine);
     YamlLoader yamlLoader = new YamlLoader();
-    private final SectionLoader sectionLoader =
+    SectionLoader sectionLoader =
             new SectionLoader(binderConfig, yamlLoader);
-    private final ManuscriptLoader manuscriptLoader =
+    ManuscriptLoader manuscriptLoader =
             new ManuscriptLoader(sectionLoader, yamlLoader, templateEngine);
     Metadata metadata = manuscriptLoader.metadata(binderConfig);
     MdManuscript mdManuscript = manuscriptLoader.mdManuscript(metadata);
     MarkdownToHtml markdownToHtml = new MarkdownToHtmlProducer()
             .markdownToHtml(templateEngine, mdManuscript);
-    HtmlFactory htmlFactory = new HtmlFactory(
-            binderConfig,
-            mdManuscript,
-            markdownToHtml
-    );
     EpubContentFactory epubContentFactory = new EpubContentFactory();
     EpubFactory epubFactory;
 
@@ -59,13 +54,10 @@ public class BinderTest
 
     @Mock EpubWriter epubWriter;
     @Mock DocxWriter docxWriter;
+    @Mock Instance<ManuscriptWriter> writers;
 
     BinderApp app;
-
     EpubBook epubBook;
-    @Mock
-    private Instance<ManuscriptWriter> writers;
-
 
     @BeforeEach
     void setUp() {
@@ -73,23 +65,13 @@ public class BinderTest
         epubFactory = new EpubFactory(binderConfig, htmlManuscript, epubContentFactory);
         docxFactory = new DocxFactory(binderConfig, htmlManuscript, docxContextFactory);
         given(writers.stream()).willReturn(Stream.of(epubWriter, docxWriter));
-        app = new BinderApp(
-                writers,
-                htmlFactory,
-                epubFactory,
-                epubWriter,
-                docxWriter,
-                docxFactory);
+        app = new BinderApp(writers);
         //when
         app.run(new String[] {});
         epubBook = epubFactory.create();
         //then
         verify(epubWriter).write();
     }
-
-
-    @Captor
-    ArgumentCaptor<EpubBook> writerCaptor;
 
     @Test
     void metadata() {

--- a/binder-app/src/test/java/net/kemitix/binder/app/BinderTest.java
+++ b/binder-app/src/test/java/net/kemitix/binder/app/BinderTest.java
@@ -75,10 +75,9 @@ public class BinderTest
                 docxFactory);
         //when
         app.run(new String[] {});
+        epubBook = epubFactory.create();
         //then
-        verify(epubWriter).write(writerCaptor.capture());
-        epubBook = writerCaptor.getValue();
-    }
+        verify(epubWriter).write();    }
 
     @Captor
     ArgumentCaptor<EpubBook> writerCaptor;

--- a/binder-app/src/test/java/net/kemitix/binder/app/BinderTest.java
+++ b/binder-app/src/test/java/net/kemitix/binder/app/BinderTest.java
@@ -18,8 +18,11 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import javax.enterprise.inject.Instance;
 import java.io.File;
+import java.util.stream.Stream;
 
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -60,6 +63,8 @@ public class BinderTest
     BinderApp app;
 
     EpubBook epubBook;
+    @Mock
+    private Instance<ManuscriptWriter> writers;
 
 
     @BeforeEach
@@ -67,7 +72,9 @@ public class BinderTest
         HtmlManuscript htmlManuscript = manuscriptLoader.htmlManuscript(mdManuscript, markdownToHtml);
         epubFactory = new EpubFactory(binderConfig, htmlManuscript, epubContentFactory);
         docxFactory = new DocxFactory(binderConfig, htmlManuscript, docxContextFactory);
+        given(writers.stream()).willReturn(Stream.of(epubWriter, docxWriter));
         app = new BinderApp(
+                writers,
                 htmlFactory,
                 epubFactory,
                 epubWriter,
@@ -77,7 +84,9 @@ public class BinderTest
         app.run(new String[] {});
         epubBook = epubFactory.create();
         //then
-        verify(epubWriter).write();    }
+        verify(epubWriter).write();
+    }
+
 
     @Captor
     ArgumentCaptor<EpubBook> writerCaptor;

--- a/binder-app/src/test/java/net/kemitix/binder/app/BinderTest.java
+++ b/binder-app/src/test/java/net/kemitix/binder/app/BinderTest.java
@@ -40,7 +40,7 @@ public class BinderTest
     private final ManuscriptLoader manuscriptLoader =
             new ManuscriptLoader(sectionLoader, yamlLoader, templateEngine);
     Metadata metadata = manuscriptLoader.metadata(binderConfig);
-    MdManuscript mdManuscript = manuscriptLoader.manuscript(metadata);
+    MdManuscript mdManuscript = manuscriptLoader.mdManuscript(metadata);
     MarkdownToHtml markdownToHtml = new MarkdownToHtmlProducer()
             .markdownToHtml(templateEngine, mdManuscript);
     HtmlFactory htmlFactory = new HtmlFactory(
@@ -49,10 +49,10 @@ public class BinderTest
             markdownToHtml
     );
     EpubContentFactory epubContentFactory = new EpubContentFactory();
-    EpubFactory epubFactory = new EpubFactory(binderConfig, mdManuscript, epubContentFactory);
+    EpubFactory epubFactory;
 
     DocxContentFactory docxContextFactory = new DocxContentFactory();
-    DocxFactory docxFactory = new DocxFactory(binderConfig, mdManuscript, docxContextFactory);
+    DocxFactory docxFactory;
 
     @Mock EpubWriter epubWriter;
     @Mock DocxWriter docxWriter;
@@ -64,6 +64,9 @@ public class BinderTest
 
     @BeforeEach
     void setUp() {
+        HtmlManuscript htmlManuscript = manuscriptLoader.htmlManuscript(mdManuscript, markdownToHtml);
+        epubFactory = new EpubFactory(binderConfig, htmlManuscript, epubContentFactory);
+        docxFactory = new DocxFactory(binderConfig, htmlManuscript, docxContextFactory);
         app = new BinderApp(
                 htmlFactory,
                 epubFactory,

--- a/binder-app/src/test/java/net/kemitix/binder/app/BinderTest.java
+++ b/binder-app/src/test/java/net/kemitix/binder/app/BinderTest.java
@@ -40,19 +40,19 @@ public class BinderTest
     private final ManuscriptLoader manuscriptLoader =
             new ManuscriptLoader(sectionLoader, yamlLoader, templateEngine);
     Metadata metadata = manuscriptLoader.metadata(binderConfig);
-    Manuscript manuscript = manuscriptLoader.manuscript(metadata);
+    MdManuscript mdManuscript = manuscriptLoader.manuscript(metadata);
     MarkdownToHtml markdownToHtml = new MarkdownToHtmlProducer()
-            .markdownToHtml(templateEngine, manuscript);
+            .markdownToHtml(templateEngine, mdManuscript);
     HtmlFactory htmlFactory = new HtmlFactory(
             binderConfig,
-            manuscript,
+            mdManuscript,
             markdownToHtml
     );
     EpubContentFactory epubContentFactory = new EpubContentFactory();
-    EpubFactory epubFactory = new EpubFactory(binderConfig, manuscript, epubContentFactory);
+    EpubFactory epubFactory = new EpubFactory(binderConfig, mdManuscript, epubContentFactory);
 
     DocxContentFactory docxContextFactory = new DocxContentFactory();
-    DocxFactory docxFactory = new DocxFactory(binderConfig, manuscript, docxContextFactory);
+    DocxFactory docxFactory = new DocxFactory(binderConfig, mdManuscript, docxContextFactory);
 
     @Mock EpubWriter epubWriter;
     @Mock DocxWriter docxWriter;

--- a/binder-app/src/test/java/net/kemitix/binder/app/HtmlFactoryTest.java
+++ b/binder-app/src/test/java/net/kemitix/binder/app/HtmlFactoryTest.java
@@ -24,7 +24,7 @@ public class HtmlFactoryTest
     SectionLoader sectionLoader = new SectionLoader(binderConfig, yamlLoader);
     ManuscriptLoader manuscriptLoader = new ManuscriptLoader(sectionLoader, yamlLoader, templateEngine);
     Metadata metadata;
-    Manuscript manuscript;
+    MdManuscript mdManuscript;
     MarkdownToHtml markdownToHtml;
     HtmlFactory htmlFactory;
 
@@ -32,10 +32,10 @@ public class HtmlFactoryTest
     void setUp() {
         scanDirectory.set(validDirectory);
         metadata = manuscriptLoader.metadata(binderConfig);
-        manuscript = manuscriptLoader.manuscript(metadata);
+        mdManuscript = manuscriptLoader.manuscript(metadata);
         markdownToHtml = new MarkdownToHtmlProducer()
-                .markdownToHtml(templateEngine, manuscript);
-        htmlFactory = new HtmlFactory(binderConfig, manuscript, markdownToHtml);
+                .markdownToHtml(templateEngine, mdManuscript);
+        htmlFactory = new HtmlFactory(binderConfig, mdManuscript, markdownToHtml);
     }
 
     @Test

--- a/binder-app/src/test/java/net/kemitix/binder/app/HtmlFactoryTest.java
+++ b/binder-app/src/test/java/net/kemitix/binder/app/HtmlFactoryTest.java
@@ -32,7 +32,7 @@ public class HtmlFactoryTest
     void setUp() {
         scanDirectory.set(validDirectory);
         metadata = manuscriptLoader.metadata(binderConfig);
-        mdManuscript = manuscriptLoader.manuscript(metadata);
+        mdManuscript = manuscriptLoader.mdManuscript(metadata);
         markdownToHtml = new MarkdownToHtmlProducer()
                 .markdownToHtml(templateEngine, mdManuscript);
         htmlFactory = new HtmlFactory(binderConfig, mdManuscript, markdownToHtml);

--- a/binder-app/src/test/java/net/kemitix/binder/app/MdManuscriptLoaderTest.java
+++ b/binder-app/src/test/java/net/kemitix/binder/app/MdManuscriptLoaderTest.java
@@ -117,7 +117,7 @@ public class MdManuscriptLoaderTest
         @Test
         void loadAndParsePrelude1() {
             //when
-            MdManuscript mdManuscript = manuscriptLoader.manuscript(metadata);
+            MdManuscript mdManuscript = manuscriptLoader.mdManuscript(metadata);
             //then
             List<Section> prelude1s = mdManuscript.getContents()
                     .stream()
@@ -140,7 +140,7 @@ public class MdManuscriptLoaderTest
         @Test
         void loadAndParsePrelude2() {
             //when
-            MdManuscript mdManuscript = manuscriptLoader.manuscript(metadata);
+            MdManuscript mdManuscript = manuscriptLoader.mdManuscript(metadata);
             //then
             List<Section> prelude1s = mdManuscript.getContents()
                     .stream()

--- a/binder-app/src/test/java/net/kemitix/binder/app/MdManuscriptLoaderTest.java
+++ b/binder-app/src/test/java/net/kemitix/binder/app/MdManuscriptLoaderTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-public class ManuscriptLoaderTest
+public class MdManuscriptLoaderTest
         implements WithAssertions {
 
     AtomicReference<File> scanDirectory = new AtomicReference<>();
@@ -104,7 +104,7 @@ public class ManuscriptLoaderTest
 
     @Nested
     @DisplayName("Manuscript contents")
-    public class ManuscriptContentsTests {
+    public class MdManuscriptContentsTests {
 
         private Metadata metadata;
 
@@ -117,9 +117,9 @@ public class ManuscriptLoaderTest
         @Test
         void loadAndParsePrelude1() {
             //when
-            Manuscript manuscript = manuscriptLoader.manuscript(metadata);
+            MdManuscript mdManuscript = manuscriptLoader.manuscript(metadata);
             //then
-            List<Section> prelude1s = manuscript.getContents()
+            List<Section> prelude1s = mdManuscript.getContents()
                     .stream()
                     .filter(section -> "prelude-1".equals(section.getName()))
                     .collect(Collectors.toList());
@@ -140,9 +140,9 @@ public class ManuscriptLoaderTest
         @Test
         void loadAndParsePrelude2() {
             //when
-            Manuscript manuscript = manuscriptLoader.manuscript(metadata);
+            MdManuscript mdManuscript = manuscriptLoader.manuscript(metadata);
             //then
-            List<Section> prelude1s = manuscript.getContents()
+            List<Section> prelude1s = mdManuscript.getContents()
                     .stream()
                     .filter(section -> "prelude-2".equals(section.getName()))
                     .collect(Collectors.toList());


### PR DESCRIPTION
Rather than dictating in `BinderApp` what, and how, create each manuscript format, jsst accept a list of `ManuscriptWriter` implementations, and write them.