### PR TITLE
Fixes for copyrights page and empty headers/footers

### DIFF
--- a/binder-app/pom.xml
+++ b/binder-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>binder-parent</artifactId>
         <groupId>net.kemitix.binder</groupId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../binder-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/binder-app/src/main/java/net/kemitix/binder/app/TemplateEngine.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/TemplateEngine.java
@@ -74,7 +74,7 @@ public class TemplateEngine {
     private String copyrights(MdManuscript mdManuscript) {
         return mdManuscript.getContents().stream()
                 .filter(Section.Type.story::isA)
-                .map(section -> "%s ©%s by%s%s".formatted(
+                .map(section -> "*%s* ©%s by%s%s".formatted(
                         section.getTitle(),
                         section.getCopyright(),
                         NON_BREAKING_SPACE,

--- a/binder-app/src/main/java/net/kemitix/binder/app/TemplateEngine.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/TemplateEngine.java
@@ -80,7 +80,7 @@ public class TemplateEngine {
                         NON_BREAKING_SPACE,
                         unBreakable(section.getAuthor())
                 ))
-                .collect(Collectors.joining("\n\n"));
+                .collect(Collectors.joining("  \n"));
     }
 
     private String unBreakable(String s) {

--- a/binder-docx/pom.xml
+++ b/binder-docx/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>binder-parent</artifactId>
         <groupId>net.kemitix.binder</groupId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../binder-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/binder-docx/src/main/java/net/kemitix/binder/docx/DocxFacadeFooterMixIn.java
+++ b/binder-docx/src/main/java/net/kemitix/binder/docx/DocxFacadeFooterMixIn.java
@@ -17,7 +17,7 @@ public interface DocxFacadeFooterMixIn
         extends DocxFacadeParagraphMixIn {
     
     default void addBlankPageFooter(SectPr sectPr, String name) {
-        P[] emptyP = {};
+        P[] emptyP = new P[]{zeroSpaceAfterP(p()), p()};
         addPageFooter(sectPr, name, HdrFtrRef.DEFAULT, emptyP);
         addPageFooter(sectPr, name, HdrFtrRef.EVEN, emptyP);
         addPageFooter(sectPr, name, HdrFtrRef.FIRST, emptyP);

--- a/binder-docx/src/main/java/net/kemitix/binder/docx/DocxFacadeHeaderMixIn.java
+++ b/binder-docx/src/main/java/net/kemitix/binder/docx/DocxFacadeHeaderMixIn.java
@@ -17,7 +17,7 @@ public interface DocxFacadeHeaderMixIn
         extends DocxFacadeParagraphMixIn {
 
     default void addBlankPageHeader(SectPr sectPr, String name) {
-        P[] emptyP = {};
+        P[] emptyP = new P[]{zeroSpaceAfterP(p()), p()};
         addPageHeader(sectPr, name, HdrFtrRef.DEFAULT, emptyP);
         addPageHeader(sectPr, name, HdrFtrRef.EVEN, emptyP);
         addPageHeader(sectPr, name, HdrFtrRef.FIRST, emptyP);

--- a/binder-docx/src/main/java/net/kemitix/binder/docx/DocxFacadeRunMixIn.java
+++ b/binder-docx/src/main/java/net/kemitix/binder/docx/DocxFacadeRunMixIn.java
@@ -1,5 +1,6 @@
 package net.kemitix.binder.docx;
 
+import org.docx4j.wml.Br;
 import org.docx4j.wml.FldChar;
 import org.docx4j.wml.R;
 import org.docx4j.wml.RPr;
@@ -97,4 +98,7 @@ public interface DocxFacadeRunMixIn
         return rStyle;
     }
 
+    default Br textLineBreak() {
+        return factory().createBr();
+    }
 }

--- a/binder-docx/src/main/java/net/kemitix/binder/docx/mdconvert/HardLineBreakDocxNodeHandler.java
+++ b/binder-docx/src/main/java/net/kemitix/binder/docx/mdconvert/HardLineBreakDocxNodeHandler.java
@@ -1,0 +1,24 @@
+package net.kemitix.binder.docx.mdconvert;
+
+import net.kemitix.binder.docx.DocxFacadeRunMixIn;
+import net.kemitix.binder.markdown.HardLineBreakNodeHandler;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.stream.Stream;
+
+@Docx
+@ApplicationScoped
+public class HardLineBreakDocxNodeHandler
+        implements HardLineBreakNodeHandler<Object> {
+
+    @Inject DocxFacadeRunMixIn docx;
+
+    @Override
+    public Stream<Object> lineBreak() {
+        return Stream.of(
+                docx.textLineBreak()
+        );
+    }
+
+}

--- a/binder-epub/pom.xml
+++ b/binder-epub/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>binder-parent</artifactId>
         <groupId>net.kemitix.binder</groupId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../binder-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/binder-epub/src/main/java/net/kemitix/binder/epub/mdconvert/HardLineBreakEpubNodeHandler.java
+++ b/binder-epub/src/main/java/net/kemitix/binder/epub/mdconvert/HardLineBreakEpubNodeHandler.java
@@ -1,0 +1,20 @@
+package net.kemitix.binder.epub.mdconvert;
+
+import net.kemitix.binder.markdown.HardLineBreakNodeHandler;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.util.stream.Stream;
+
+@Epub
+@ApplicationScoped
+public class HardLineBreakEpubNodeHandler
+        implements HardLineBreakNodeHandler<String> {
+
+    @Override
+    public Stream<String> lineBreak() {
+        return Stream.of(
+                "<br/>"
+        );
+    }
+
+}

--- a/binder-markdown/pom.xml
+++ b/binder-markdown/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>binder-parent</artifactId>
         <groupId>net.kemitix.binder</groupId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../binder-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/binder-markdown/src/main/java/net/kemitix/binder/markdown/HardLineBreakNodeHandler.java
+++ b/binder-markdown/src/main/java/net/kemitix/binder/markdown/HardLineBreakNodeHandler.java
@@ -1,0 +1,23 @@
+package net.kemitix.binder.markdown;
+
+import com.vladsch.flexmark.ast.HardLineBreak;
+import com.vladsch.flexmark.util.ast.Node;
+
+import java.util.stream.Stream;
+
+public interface HardLineBreakNodeHandler<T>
+        extends NodeHandler<T> {
+
+    @Override
+    default Class<? extends Node> getNodeClass() {
+        return HardLineBreak.class;
+    }
+
+    @Override
+    default Stream<T> body(Node node, Stream<T> content, Context context) {
+        return lineBreak();
+    }
+
+    Stream<T> lineBreak();
+
+}

--- a/binder-parent/pom.xml
+++ b/binder-parent/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.kemitix.binder</groupId>
     <artifactId>binder-parent</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/binder-spi/pom.xml
+++ b/binder-spi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>binder-parent</artifactId>
         <groupId>net.kemitix.binder</groupId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../binder-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/binder/pom.xml
+++ b/binder/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>binder-parent</artifactId>
         <groupId>net.kemitix.binder</groupId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../binder-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/binder/src/main/java/net/kemitix/binder/BinderMain.java
+++ b/binder/src/main/java/net/kemitix/binder/BinderMain.java
@@ -1,6 +1,5 @@
 package net.kemitix.binder;
 
-import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.annotations.QuarkusMain;
 import net.kemitix.binder.app.BinderApp;

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>net.kemitix.binder</groupId>
     <artifactId>binder-root</artifactId>
     <name>binder-root</name>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
- Story titles on copyright page are italicised
- Use a line break between stories on copyright page (rather than paragraph break)
- Preserve vertical space of empty headers/footers