### PR TITLE
Upgrade Quarkus to 2.0

### DIFF
--- a/binder-markdown/src/main/java/net/kemitix/binder/markdown/MarkdownConverter.java
+++ b/binder-markdown/src/main/java/net/kemitix/binder/markdown/MarkdownConverter.java
@@ -26,9 +26,14 @@ public interface MarkdownConverter<T, R extends RenderHolder<?>> {
         return document;
     }
 
-    default Stream<T> accept(Node node, Context<R> context) {
-        NodeHandler<T, R> handler = findHandler(node.getClass());
-        return handler.handle(node, this, context);
+    default Stream<T> accept(Node rootNode, Context<R> context) {
+        final Stream.Builder<T> builder = Stream.builder();
+        Nodes.of(rootNode).getNodes().forEach(node -> {
+            findHandler(node.getClass())
+                    .handle(node, this, context)
+                    .forEach(builder);
+        });
+        return builder.build();
     }
 
     default NodeHandler<T, R> findHandler(Class<? extends Node> aClass) {

--- a/binder-markdown/src/main/java/net/kemitix/binder/markdown/NodeHandler.java
+++ b/binder-markdown/src/main/java/net/kemitix/binder/markdown/NodeHandler.java
@@ -20,16 +20,9 @@ public interface NodeHandler<T, R extends RenderHolder<?>> {
             MarkdownConverter<T, R> converter,
             Context<R> context
     ) {
-        Stream<T> children = handleChildren(node, converter, context);
-        return Stream.concat(
-                requireNonNull(body(node, children, context), "body", node),
-                requireNonNull(handleNext(node, converter, context), "handleNext", node)
-        );
-    }
-
-    default <O> O requireNonNull(O object, String tag, Node node) {
+        Stream<T> object = body(node, handleChildren(node, converter, context), context);
         if (Objects.isNull(object)) {
-            throw new MarkdownOutputException("Element is null: %s [%s]".formatted(tag, node.toString()), node.toString());
+            throw new MarkdownOutputException("Element is null", node.toString());
         }
         return object;
     }

--- a/binder-markdown/src/main/java/net/kemitix/binder/markdown/Nodes.java
+++ b/binder-markdown/src/main/java/net/kemitix/binder/markdown/Nodes.java
@@ -1,0 +1,29 @@
+package net.kemitix.binder.markdown;
+
+import com.vladsch.flexmark.util.ast.Node;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Nodes {
+
+    final List<Node> nodes;
+
+    private Nodes(Node node) {
+        nodes = new ArrayList<>();
+        nodes.add(node);
+        Node next = node.getNext();
+        while (next != null) {
+            nodes.add(next);
+            next = next.getNext();
+        }
+    }
+
+    public static Nodes of(Node node) {
+        return new Nodes(node);
+    }
+
+    public List<Node> getNodes() {
+        return new ArrayList<>(nodes);
+    }
+}

--- a/binder/pom.xml
+++ b/binder/pom.xml
@@ -18,17 +18,15 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.version>1.12.2.Final</quarkus.version>
+        <quarkus.version>2.0.3.Final</quarkus.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
         <lombok.version>1.18.20</lombok.version>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-universe-bom</artifactId>
                 <version>${quarkus.version}</version>
                 <type>pom</type>
                 <scope>import</scope>


### PR DESCRIPTION
Given Quarkus has yet to decide if they will support Jakarta EE 9.0, switching to the reference implementation of CDI, to be able to keep up with latest Jakarta EE.