### PR TITLE
Multiple runs with the same input produces the same file (i.e. fixed timestamps)

### DIFF
--- a/binder-epub/src/main/java/net/kemitix/binder/epub/EpubFactory.java
+++ b/binder-epub/src/main/java/net/kemitix/binder/epub/EpubFactory.java
@@ -138,10 +138,12 @@ public class EpubFactory {
         EpubBook epubBook = new EpubBook(language, id, title, editor);
         MetadataItem.Builder mib = MetadataItem.builder();
         var meta = mib.name("meta");
+        var dateTime = metadata.getDate() + "T00:00:00+00:00";
         var metadataItems = Arrays.asList(
+                mib.name("meta").property("dcterms:modified").value(dateTime),
                 mib.name("dc:description").value(metadata.getDescription()),
                 mib.name("dc:contributor").id("editor-id").value(metadata.getEditor()),
-                mib.name("dc:date").value(metadata.getDate()+"T00:00:00+00:00"),
+                mib.name("dc:date").value(dateTime),
                 mib.name("dc:publisher").value(editor),
                 meta.property("role").refines("#editor-id").value("Editor"),
                 meta.id("collection-id").property("belongs-to-collection").value(metadata.getTitle()),

--- a/binder-epub/src/main/java/net/kemitix/binder/epub/EpubFactory.java
+++ b/binder-epub/src/main/java/net/kemitix/binder/epub/EpubFactory.java
@@ -130,20 +130,21 @@ public class EpubFactory {
             Metadata metadata,
             Stream<HtmlSection> sections
     ) {
-        String language = metadata.getLanguage();
-        String id = Objects.requireNonNull(metadata.getId(), "metadata id");
-        String title = "%s Issue %d".formatted(
+        var language = metadata.getLanguage();
+        var id = Objects.requireNonNull(metadata.getId(), "metadata id");
+        var title = "%s Issue %d".formatted(
                 metadata.getTitle(), metadata.getIssue());
-        String editor = metadata.getEditor();
-        EpubBook epubBook = new EpubBook(language, id, title, editor);
-        MetadataItem.Builder mib = MetadataItem.builder();
+        var editor = metadata.getEditor();
+        var epubBook = new EpubBook(language, id, title, editor);
+        var mib = MetadataItem.builder();
         var meta = mib.name("meta");
-        var dateTime = metadata.getDate() + "T00:00:00+00:00";
+        var date = Objects.requireNonNull(metadata.getDate(), "metadata date");
+        var modified = Objects.requireNonNull(metadata.getModified(), "metadata modified");
         var metadataItems = Arrays.asList(
-                mib.name("meta").property("dcterms:modified").value(dateTime),
+                mib.name("meta").property("dcterms:modified").value(modified + "T00:00:00+00:00"),
                 mib.name("dc:description").value(metadata.getDescription()),
                 mib.name("dc:contributor").id("editor-id").value(metadata.getEditor()),
-                mib.name("dc:date").value(dateTime),
+                mib.name("dc:date").value(date + "T00:00:00+00:00"),
                 mib.name("dc:publisher").value(editor),
                 meta.property("role").refines("#editor-id").value("Editor"),
                 meta.id("collection-id").property("belongs-to-collection").value(metadata.getTitle()),
@@ -154,8 +155,9 @@ public class EpubFactory {
         var dcCreator = mib.name("dc:creator");
         sections.map(Section::getAuthor)
                 .filter(Objects::nonNull)
-                .map(dcCreator::value)
-                .forEach(epubBook::addMetadata);
+                .findFirst()
+                .map(mib.name("dc:creator")::value)
+                .ifPresent(epubBook::addMetadata);
         return epubBook;
     }
 }

--- a/binder-spi/src/main/java/net/kemitix/binder/spi/Metadata.java
+++ b/binder-spi/src/main/java/net/kemitix/binder/spi/Metadata.java
@@ -16,6 +16,7 @@ public class Metadata {
     private String id;
     private int issue;
     private String date;
+    private String modified;
     private String copyright;
     private String language;
     private String title;


### PR DESCRIPTION
`meta property="dcterms:modified"`