### PR TITLE
Modified date should default to published date unless specified

### DIFF
--- a/binder-docx/src/main/java/net/kemitix/binder/docx/DocxFacadeFootnoteMixIn.java
+++ b/binder-docx/src/main/java/net/kemitix/binder/docx/DocxFacadeFootnoteMixIn.java
@@ -15,7 +15,7 @@ import org.docx4j.wml.R;
 import org.docx4j.wml.RPr;
 import org.docx4j.wml.STFtnEdn;
 
-import jakarta.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBElement;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/binder-docx/src/main/java/net/kemitix/binder/docx/DocxFacadeRunMixIn.java
+++ b/binder-docx/src/main/java/net/kemitix/binder/docx/DocxFacadeRunMixIn.java
@@ -9,7 +9,7 @@ import org.docx4j.wml.STBrType;
 import org.docx4j.wml.STFldCharType;
 import org.docx4j.wml.Text;
 
-import jakarta.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBElement;
 import java.util.Arrays;
 
 public interface DocxFacadeRunMixIn

--- a/binder-docx/src/main/java/net/kemitix/binder/docx/DocxManuscript.java
+++ b/binder-docx/src/main/java/net/kemitix/binder/docx/DocxManuscript.java
@@ -19,7 +19,7 @@ import org.docx4j.wml.*;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import jakarta.xml.bind.JAXBException;
+import javax.xml.bind.JAXBException;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;

--- a/binder-epub/src/main/java/net/kemitix/binder/epub/EpubFactory.java
+++ b/binder-epub/src/main/java/net/kemitix/binder/epub/EpubFactory.java
@@ -158,12 +158,10 @@ public class EpubFactory {
                 meta.property("group-position").refines("#collection-id").value(Integer.toString(metadata.getIssue()))
         );
         metadataItems.forEach(epubBook::addMetadata);
-        var dcCreator = mib.name("dc:creator");
         sections.map(Section::getAuthor)
                 .filter(Objects::nonNull)
-                .findFirst()
                 .map(mib.name("dc:creator")::value)
-                .ifPresent(epubBook::addMetadata);
+                .forEach(epubBook::addMetadata);
         return epubBook;
     }
 }

--- a/binder-epub/src/main/java/net/kemitix/binder/epub/EpubFactory.java
+++ b/binder-epub/src/main/java/net/kemitix/binder/epub/EpubFactory.java
@@ -5,6 +5,7 @@ import coza.opencollab.epub.creator.model.Content;
 import coza.opencollab.epub.creator.model.EpubBook;
 import coza.opencollab.epub.creator.model.Landmark;
 import coza.opencollab.epub.creator.model.TocLink;
+import lombok.extern.java.Log;
 import net.kemitix.binder.spi.BinderConfig;
 import net.kemitix.binder.spi.Context;
 import net.kemitix.binder.spi.HtmlManuscript;
@@ -23,8 +24,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 
+@Log
 @ApplicationScoped
 public class EpubFactory {
 
@@ -139,7 +142,10 @@ public class EpubFactory {
         var mib = MetadataItem.builder();
         var meta = mib.name("meta");
         var date = Objects.requireNonNull(metadata.getDate(), "metadata date");
-        var modified = Objects.requireNonNull(metadata.getModified(), "metadata modified");
+        var modified = Optional.ofNullable(metadata.getModified()).orElseGet(() -> {
+            log.warning("Modified date not specified, defaulting to publication date");
+            return date;
+        });
         var metadataItems = Arrays.asList(
                 mib.name("meta").property("dcterms:modified").value(modified + "T00:00:00+00:00"),
                 mib.name("dc:description").value(metadata.getDescription()),

--- a/binder-parent/pom.xml
+++ b/binder-parent/pom.xml
@@ -27,7 +27,7 @@
         <snakeyaml.version>1.30</snakeyaml.version>
         <epub-creator.version>1.2.0</epub-creator.version>
         <docx4j-ImportXHTML.version>8.3.2</docx4j-ImportXHTML.version>
-        <docx4j-JAXB-ReferenceImpl.version>11.4.5</docx4j-JAXB-ReferenceImpl.version>
+        <docx4j-JAXB-ReferenceImpl.version>11.3.2</docx4j-JAXB-ReferenceImpl.version>
         <velocity-engine.version>2.3</velocity-engine.version>
         <awt-color-factory.version>1.0.2</awt-color-factory.version>
         <mon.version>3.2.0</mon.version>


### PR DESCRIPTION
Makes the newly added modified field optional, and restores backward compatibility with existing binder sources.

Also:
- reverts upgrade of docx4j-JAXB-ReferenceImpl that prevents quarkus startup
- fixes bug where only the first author was added as `dc:creator` metadata