### PR TITLE
Produce Epub passing epubcheck EPUB 3.2 rules

### DIFF
--- a/binder-app/src/main/java/net/kemitix/binder/app/TemplateEngine.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/TemplateEngine.java
@@ -2,6 +2,7 @@ package net.kemitix.binder.app;
 
 import net.kemitix.binder.spi.MdManuscript;
 import net.kemitix.binder.spi.Section;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.context.Context;
 
@@ -38,7 +39,7 @@ public class TemplateEngine {
         velocityContext.put("s", section);
         velocityContext.put("m", mdManuscript.getMetadata());
         velocityContext.put("c", mdManuscript.getContents());
-        velocityContext.put("copyrights", copyrights(mdManuscript));
+        velocityContext.put("copyrights", encode(copyrights(mdManuscript)));
         velocityContext.put("toc", toc(mdManuscript));
         Writer writer = new StringWriter();
         // Double hashes are comments in velocity, but at the start of a line
@@ -81,6 +82,10 @@ public class TemplateEngine {
                         unBreakable(section.getAuthor())
                 ))
                 .collect(Collectors.joining("  \n"));
+    }
+
+    String encode(String in) {
+        return StringEscapeUtils.escapeXml11(in);
     }
 
     private String unBreakable(String s) {

--- a/binder-app/src/main/java/net/kemitix/binder/app/TemplateEngine.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/TemplateEngine.java
@@ -39,7 +39,7 @@ public class TemplateEngine {
         velocityContext.put("s", section);
         velocityContext.put("m", mdManuscript.getMetadata());
         velocityContext.put("c", mdManuscript.getContents());
-        velocityContext.put("copyrights", encode(copyrights(mdManuscript)));
+        velocityContext.put("copyrights", copyrights(mdManuscript));
         velocityContext.put("toc", toc(mdManuscript));
         Writer writer = new StringWriter();
         // Double hashes are comments in velocity, but at the start of a line
@@ -47,7 +47,7 @@ public class TemplateEngine {
         // This style of comment is not supported, and are broken
         velocityEngine.evaluate(velocityContext, writer, "",
                 templateBody.replaceAll(DOUBLE_HASH, NOT_A_COMMENT));
-        return writer.toString()
+        return encode(writer.toString())
                 .replaceAll(NOT_A_COMMENT, DOUBLE_HASH);
     }
 

--- a/binder-app/src/main/java/net/kemitix/binder/app/YamlLoader.java
+++ b/binder-app/src/main/java/net/kemitix/binder/app/YamlLoader.java
@@ -12,15 +12,10 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class YamlLoader {
-
-    public static final Pattern UNSAFE_AMP_PATTERN = Pattern.compile("&[^a]");
 
     public  <T> T loadFile(
             File file,
@@ -44,22 +39,12 @@ public class YamlLoader {
                 .takeWhile(line -> !line.equals("---"))
                 .collect(Collectors.toList());
         int headerLines = header.size() + 2;
-        AtomicInteger lineCounter = new AtomicInteger(headerLines);
         String body = lines.stream().skip(headerLines)
-                .map(line -> validateContent(line, file, lineCounter.incrementAndGet()))
                 .collect(Collectors.joining(System.lineSeparator()));
         Section section = parseYamlFromFile(file, Section.class,
                 String.join(System.lineSeparator(), header));
         section.setMarkdown(body);
         return section;
-    }
-
-    private String validateContent(String body, File file, int lineCounter) {
-        if (UNSAFE_AMP_PATTERN.matcher(body).find()) {
-            throw new RuntimeException("Invalid unescaped ampersand in %s at line %d"
-                    .formatted(file, lineCounter));
-        }
-        return body;
     }
 
     private List<String> loadRequiredFile(File file) {

--- a/binder-epub/src/main/java/net/kemitix/binder/epub/EpubFactory.java
+++ b/binder-epub/src/main/java/net/kemitix/binder/epub/EpubFactory.java
@@ -147,7 +147,7 @@ public class EpubFactory {
             return date;
         });
         var metadataItems = Arrays.asList(
-                mib.name("meta").property("dcterms:modified").value(modified + "T00:00:00+00:00"),
+                mib.name("meta").property("dcterms:modified").value(modified + "T00:00:00Z"),
                 mib.name("dc:description").value(metadata.getDescription()),
                 mib.name("dc:contributor").id("editor-id").value(metadata.getEditor()),
                 mib.name("dc:date").value(date + "T00:00:00+00:00"),

--- a/binder-epub/src/main/java/net/kemitix/binder/epub/StoryEpubTocItemRenderer.java
+++ b/binder-epub/src/main/java/net/kemitix/binder/epub/StoryEpubTocItemRenderer.java
@@ -3,6 +3,7 @@ package net.kemitix.binder.epub;
 import net.kemitix.binder.spi.Context;
 import net.kemitix.binder.spi.HtmlSection;
 import net.kemitix.binder.spi.Section;
+import org.apache.commons.text.StringEscapeUtils;
 
 import javax.enterprise.context.ApplicationScoped;
 import java.util.stream.Stream;
@@ -30,7 +31,7 @@ public class StoryEpubTocItemRenderer
                         </li>
                         """.formatted(
                         section.getHref(),
-                        section.getTitle(),
+                        StringEscapeUtils.escapeXml11(section.getTitle()),
                         section.getAuthor(),
                         section.getGenre(),
                         section.getWords()));

--- a/binder-epub/src/main/java/net/kemitix/binder/epub/mdconvert/DocumentEpubNodeHandler.java
+++ b/binder-epub/src/main/java/net/kemitix/binder/epub/mdconvert/DocumentEpubNodeHandler.java
@@ -57,6 +57,7 @@ public class DocumentEpubNodeHandler
             String author,
             Stream<String> content
     ) {
+        final String storyTitle = StringEscapeUtils.escapeXml11(Objects.requireNonNull(title, "Story title"));
         return Stream.of(
                 """
                         <?xml version='1.0' encoding='utf-8'?>
@@ -65,6 +66,7 @@ public class DocumentEpubNodeHandler
                          xmlns="http://www.w3.org/1999/xhtml"
                          xmlns:epub="http://www.idpf.org/2007/ops">
                         <head>
+                        <title>%s</title>
                         <link rel="stylesheet" href="%s" type="text/css" media="all"/>
                         </head>
                         <body>
@@ -74,8 +76,9 @@ public class DocumentEpubNodeHandler
                         </body>
                         </html>
                         """.formatted(
+                        storyTitle,
                         stylesheetHref,
-                        StringEscapeUtils.escapeXml11(Objects.requireNonNull(title, "Story title")),
+                        storyTitle,
                         Objects.requireNonNull(author, "Story author"),
                         collect(content)));
     }

--- a/binder-epub/src/main/java/net/kemitix/binder/epub/mdconvert/DocumentEpubNodeHandler.java
+++ b/binder-epub/src/main/java/net/kemitix/binder/epub/mdconvert/DocumentEpubNodeHandler.java
@@ -30,6 +30,7 @@ public class DocumentEpubNodeHandler
             String title,
             Stream<String> content
     ) {
+        final String storyTitle = Objects.requireNonNullElse(title, "");
         return Stream.of(
                 """
                         <?xml version='1.0' encoding='utf-8'?>
@@ -38,6 +39,7 @@ public class DocumentEpubNodeHandler
                          xmlns="http://www.w3.org/1999/xhtml"
                          xmlns:epub="http://www.idpf.org/2007/ops">
                         <head>
+                        <title>%s</title>
                         <link rel="stylesheet" href="%s" type="text/css" media="all"/>
                         </head>
                         <body>
@@ -46,8 +48,9 @@ public class DocumentEpubNodeHandler
                         </body>
                         </html>
                         """.formatted(
+                        storyTitle,
                         stylesheetHref,
-                        Objects.requireNonNullElse(title, ""),
+                        storyTitle,
                         collect(content)));
     }
 

--- a/binder-epub/src/main/java/net/kemitix/binder/epub/mdconvert/DocumentEpubNodeHandler.java
+++ b/binder-epub/src/main/java/net/kemitix/binder/epub/mdconvert/DocumentEpubNodeHandler.java
@@ -2,6 +2,7 @@ package net.kemitix.binder.epub.mdconvert;
 
 import net.kemitix.binder.epub.EpubRenderHolder;
 import net.kemitix.binder.markdown.DocumentNodeHandler;
+import org.apache.commons.text.StringEscapeUtils;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -74,7 +75,7 @@ public class DocumentEpubNodeHandler
                         </html>
                         """.formatted(
                         stylesheetHref,
-                        Objects.requireNonNull(title, "Story title"),
+                        StringEscapeUtils.escapeXml11(Objects.requireNonNull(title, "Story title")),
                         Objects.requireNonNull(author, "Story author"),
                         collect(content)));
     }

--- a/binder-markdown/src/main/java/net/kemitix/binder/markdown/BlockQuoteNodeHandler.java
+++ b/binder-markdown/src/main/java/net/kemitix/binder/markdown/BlockQuoteNodeHandler.java
@@ -19,14 +19,7 @@ public interface BlockQuoteNodeHandler<T, R extends RenderHolder<?>>
 
     @Override
     default Stream<T> body(Node node, Stream<T> content, Context<R> context) {
-        List<T> collect = content.collect(Collectors.toList());
-        if (collect.size() != 1) {
-            //noinspection unchecked
-            throw new MarkdownConversionException(
-                    "Not passed a single content item: %d sent".formatted(collect.size()),
-                    node, (List<Object>) collect, context);
-        }
-        return blockQuoteBody(collect.get(0), context);
+        return content.flatMap(item -> blockQuoteBody(item, context));
     }
 
     Stream<T> blockQuoteBody(T content, Context<R> context);

--- a/binder-markdown/src/main/java/net/kemitix/binder/markdown/EmphasisNodeHandler.java
+++ b/binder-markdown/src/main/java/net/kemitix/binder/markdown/EmphasisNodeHandler.java
@@ -5,8 +5,6 @@ import com.vladsch.flexmark.util.ast.Node;
 import net.kemitix.binder.spi.Context;
 import net.kemitix.binder.spi.RenderHolder;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public interface EmphasisNodeHandler<T, R extends RenderHolder<?>>
@@ -18,15 +16,12 @@ public interface EmphasisNodeHandler<T, R extends RenderHolder<?>>
     }
 
     @Override
-    default Stream<T> body(Node node, Stream<T> content, Context<R> context) {
-        List<T> collect = content.collect(Collectors.toList());
-        if (collect.size() != 1) {
-            //noinspection unchecked
-            throw new MarkdownConversionException(
-                    "Not passed a single content item: %d sent".formatted(collect.size()),
-                    node, (List<Object>) collect, context);
-        }
-        return emphasisBody(collect.get(0), context);
+    default Stream<T> body(
+            Node node,
+            Stream<T> content,
+            Context<R> context
+    ) {
+        return content.flatMap(item -> emphasisBody(item, context));
     }
 
     Stream<T> emphasisBody(T content, Context<R> context);

--- a/binder-markdown/src/main/java/net/kemitix/binder/markdown/StrikethroughNodeHandler.java
+++ b/binder-markdown/src/main/java/net/kemitix/binder/markdown/StrikethroughNodeHandler.java
@@ -19,14 +19,7 @@ public interface StrikethroughNodeHandler<T, R extends RenderHolder<?>>
 
     @Override
     default Stream<T> body(Node node, Stream<T> content, Context<R> context) {
-        List<T> collect = content.collect(Collectors.toList());
-        if (collect.size() != 1) {
-            //noinspection unchecked
-            throw new MarkdownConversionException(
-                    "Not passed a single content item: %d sent".formatted(collect.size()),
-                    node, (List<Object>) collect, context);
-        }
-        return strikethroughBody(collect.get(0), context);
+        return content.flatMap(item -> strikethroughBody(item, context));
     }
 
     Stream<T> strikethroughBody(T content, Context<R> context);

--- a/binder-markdown/src/main/java/net/kemitix/binder/markdown/StrongEmphasisNodeHandler.java
+++ b/binder-markdown/src/main/java/net/kemitix/binder/markdown/StrongEmphasisNodeHandler.java
@@ -19,12 +19,7 @@ public interface StrongEmphasisNodeHandler<T, R extends RenderHolder<?>>
 
     @Override
     default Stream<T> body(Node node, Stream<T> content, Context<R> context) {
-        List<T> collect = content.collect(Collectors.toList());
-        if (collect.size() != 1) {
-            throw new RuntimeException("Not passed a single content item: %d sent"
-                    .formatted(collect.size()));
-        }
-        return strongEmphasisBody(collect.get(0), context);
+        return content.flatMap(item -> strongEmphasisBody(item, context));
     }
 
     Stream<T> strongEmphasisBody(T content, Context<R> context);

--- a/binder-markdown/src/main/java/net/kemitix/binder/markdown/SuperscriptNodeHandler.java
+++ b/binder-markdown/src/main/java/net/kemitix/binder/markdown/SuperscriptNodeHandler.java
@@ -19,14 +19,7 @@ public interface SuperscriptNodeHandler<T, R extends RenderHolder<?>>
 
     @Override
     default Stream<T> body(Node node, Stream<T> content, Context<R> context) {
-        List<T> collect = content.collect(Collectors.toList());
-        if (collect.size() != 1) {
-            //noinspection unchecked
-            throw new MarkdownConversionException(
-                    "Not passed a single content item: %d sent".formatted(collect.size()),
-                    node, (List<Object>) collect, context);
-        }
-        return superscriptBody(collect.get(0), context);
+        return content.flatMap(item -> superscriptBody(item, context));
     }
 
     Stream<T> superscriptBody(T content, Context<R> context);


### PR DESCRIPTION
Closes #296

- Handle nested elements within blockquote, emphasis, strikethrough and superscript
- Encode HTML entities in copyright list
- Don't check for unescape ampersands - they will now be encoded
- Ensure html entities encoded in TOC
- Encode story title for html entities
- USe correct format for dcterms:modified
- Add head/title to stories in epub
- Add head/title to non-story pages in epub
