### PR TITLE
build(deps): bump commons-text from 1.9 to 1.10.0

### DIFF
--- a/binder-parent/pom.xml
+++ b/binder-parent/pom.xml
@@ -31,7 +31,7 @@
         <velocity-engine.version>2.3</velocity-engine.version>
         <awt-color-factory.version>1.0.2</awt-color-factory.version>
         <mon.version>3.2.0</mon.version>
-        <commons-text.version>1.9</commons-text.version>
+        <commons-text.version>1.10.0</commons-text.version>
         <jsoup.version>1.15.3</jsoup.version>
     </properties>
 


### PR DESCRIPTION
Bumps commons-text from 1.9 to 1.10.0.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-text
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

commit-id:a03354b6

---

**Stack**:
- #325
- #324 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*