### PR TITLE
build(deps): bump docx4j from 11.3.2 to 11.4.8

### DIFF
--- a/binder-parent/pom.xml
+++ b/binder-parent/pom.xml
@@ -26,8 +26,8 @@
         <mockito-junit-jupiter.version>4.8.0</mockito-junit-jupiter.version>
         <snakeyaml.version>1.31</snakeyaml.version>
         <epub-creator.version>1.2.0</epub-creator.version>
-        <docx4j-ImportXHTML.version>8.3.2</docx4j-ImportXHTML.version>
-        <docx4j-JAXB-ReferenceImpl.version>11.3.2</docx4j-JAXB-ReferenceImpl.version>
+        <docx4j-ImportXHTML.version>11.4.8</docx4j-ImportXHTML.version>
+        <docx4j-JAXB-ReferenceImpl.version>11.4.8</docx4j-JAXB-ReferenceImpl.version>
         <velocity-engine.version>2.3</velocity-engine.version>
         <awt-color-factory.version>1.0.2</awt-color-factory.version>
         <mon.version>3.2.0</mon.version>


### PR DESCRIPTION
Bumps docx4j-JAXB-ReferenceImpl from 11.3.2 to 11.4.8.

---
updated-dependencies:
- dependency-name: org.docx4j:docx4j-JAXB-ReferenceImpl
dependency-type: direct:production
update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

Bumps [docx4j-ImportXHTML](https://github.com/plutext/docx4j-ImportXHTML) from 8.3.2 to 11.4.8.
- [Release notes](https://github.com/plutext/docx4j-ImportXHTML/releases)
- [Changelog](https://github.com/plutext/docx4j-ImportXHTML/blob/docx4j-ImportXHTML-parent-11.4.8/CHANGELOG.md)
- [Commits](https://github.com/plutext/docx4j-ImportXHTML/compare/docx4j-ImportXHTML-8.3.2...docx4j-ImportXHTML-parent-11.4.8)

---
updated-dependencies:
- dependency-name: org.docx4j:docx4j-ImportXHTML
dependency-type: direct:production
update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>